### PR TITLE
Allow using PEM string directly

### DIFF
--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -10,10 +10,11 @@ func TestCreateCredentials(t *testing.T) {
 `
 	certificate := `
 `
+
 	os.Setenv("INPUT_PRIVATE-KEY", privateKey)
 	os.Setenv("INPUT_CERTIFICATE", certificate)
 	os.Setenv("INPUT_ROLE-ARN", "arn:aws:iam::211125334931:role/TestRole")
-	os.Setenv("INPUT_PROFILE-ARN", "arn:aws:rolesanywhere:us-east-1:211125334931:profile/89afc4fd-7b96-443b-9613-10bd828d4c24")
+	os.Setenv("INPUT_PROFILE-ARN", "arn:aws:rolesanywhere:us-east-1:211125334931:profile/eef5f646-6218-4871-bf41-db7e13f7acad")
 	os.Setenv("INPUT_TRUST-ANCHOR-ARN", "arn:aws:rolesanywhere:us-east-1:211125334931:trust-anchor/6dd648ad-92a7-4a44-a59c-2b1d56dfbbee")
 
 	tempEnv, err := createTempGitHubEnviornment(".env")

--- a/internal/util/cert_util.go
+++ b/internal/util/cert_util.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+)
+
+func GetPrivateKeyFromPEMString(pemData []byte) (crypto.PrivateKey, error) {
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return nil, fmt.Errorf("failed to parse PEM block containing the private key")
+	}
+
+	privateKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, errors.New("could not parse private key")
+	}
+
+	rsaPrivateKey, ok := privateKey.(*rsa.PrivateKey)
+	if ok {
+		return *rsaPrivateKey, nil
+	}
+
+	ecPrivateKey, ok := privateKey.(*ecdsa.PrivateKey)
+	if ok {
+		return *ecPrivateKey, nil
+	}
+
+	return nil, errors.New("could not parse PKCS#8 private key")
+}
+
+func GetCertificateFromPEM(pemData []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return nil, fmt.Errorf("failed to parse PEM block containing the certificate")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse certificate: %v", err)
+	}
+
+	return cert, nil
+}


### PR DESCRIPTION
Originally was taking the PEM string and writing it to a file to be processed.  Updated to use the PEM string directly.